### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Automatic C# bindings generator for GDExtension classes (Godot 4.4+)
 
 
 ## How does it work?
-This editor plugin contains a single script [csharp_gdextension_bindgen.gd](addons/csharp_gdextension_bindgen/csharp_gdextension_bindgen.gd) with the whole C# code generation.
+This editor plugin contains the script [csharp_gdextension_bindgen.gd](addons/csharp_gdextension_bindgen/csharp_gdextension_bindgen.gd) with the whole C# code generation.
 It uses the reflection provided by [ClassDB](https://docs.godotengine.org/en/stable/classes/class_classdb.html) to generate bindings to enums, constants, properties, methods and signals for all classes registered using the GDExtension API.
 
 The generated C# classes are in the `GDExtensionBindgen` namespace, so you'll need to add `using GDExtensionBindgen;` before using them.
@@ -20,6 +20,17 @@ The generated classes do not inherit from any `GodotObject` subclass because the
 
 ## Caveats
 - Since generated classes do not inherit `GodotObject`, there's no easy way to create C# scripts that specify the wrapped GDExtension classes as their base class
+
+
+## Generating bindings from the CLI
+This addon also contains the [cli_entrypoint.gd](addons/csharp_gdextension_bindgen/cli_entrypoint.gd) script that can be used to generate bindings via command line:
+```sh
+# Generates C# bindings for all GDExtension classes
+# Optionally pass the desired output directory and C# namespace
+godot --headless --script addons/csharp_gdextension_bindgen/cli_entrypoint.gd -- [OUTPUT_DIR] [NAMESPACE]
+```
+
+This can be used by GDExtension projects themselves as a way to distribute pre-generated C# bindings.
 
 
 ## TODO

--- a/addons/csharp_gdextension_bindgen/cli_entrypoint.gd
+++ b/addons/csharp_gdextension_bindgen/cli_entrypoint.gd
@@ -1,0 +1,11 @@
+extends SceneTree
+
+
+const CSharpGDExtensionBindgen = preload("csharp_gdextension_bindgen.gd")
+
+
+func _initialize():
+	var args = OS.get_cmdline_user_args()
+	var output_dir = CSharpGDExtensionBindgen.GENERATED_SCRIPTS_FOLDER if args.is_empty() else args[0]
+	CSharpGDExtensionBindgen.generate_gdextension_csharp_scripts(output_dir)
+	quit()

--- a/addons/csharp_gdextension_bindgen/cli_entrypoint.gd
+++ b/addons/csharp_gdextension_bindgen/cli_entrypoint.gd
@@ -5,7 +5,5 @@ const CSharpGDExtensionBindgen = preload("csharp_gdextension_bindgen.gd")
 
 
 func _initialize():
-	var args = OS.get_cmdline_user_args()
-	var output_dir = CSharpGDExtensionBindgen.GENERATED_SCRIPTS_FOLDER if args.is_empty() else args[0]
-	CSharpGDExtensionBindgen.generate_gdextension_csharp_scripts(output_dir)
+	CSharpGDExtensionBindgen.generate_gdextension_csharp_scripts.callv(OS.get_cmdline_user_args())
 	quit()

--- a/addons/csharp_gdextension_bindgen/cli_entrypoint.gd.uid
+++ b/addons/csharp_gdextension_bindgen/cli_entrypoint.gd.uid
@@ -1,0 +1,1 @@
+uid://najinjv0m445

--- a/addons/csharp_gdextension_bindgen/csharp_gdextension_bindgen.gd
+++ b/addons/csharp_gdextension_bindgen/csharp_gdextension_bindgen.gd
@@ -26,14 +26,14 @@ const StringNameTypeName = {
 
 
 func _enter_tree():
-	add_tool_menu_item(MENU_ITEM_NAME, _run)
+	add_tool_menu_item(MENU_ITEM_NAME, generate_gdextension_csharp_scripts)
 
 
 func _exit_tree():
 	remove_tool_menu_item(MENU_ITEM_NAME)
 
 
-func generate_csharp_script(cls_name: StringName):
+static func generate_csharp_script(cls_name: StringName, output_dir := GENERATED_SCRIPTS_FOLDER):
 	var class_is_editor_only = _is_editor_extension_class(cls_name)
 	var parent_class = ClassDB.get_parent_class(cls_name)
 	var parent_class_is_extension = _is_extension_class(parent_class)
@@ -247,18 +247,18 @@ func generate_csharp_script(cls_name: StringName):
 
 	code += "\n"
 
-	if not DirAccess.dir_exists_absolute(GENERATED_SCRIPTS_FOLDER):
-		DirAccess.make_dir_recursive_absolute(GENERATED_SCRIPTS_FOLDER)
+	if not DirAccess.dir_exists_absolute(output_dir):
+		DirAccess.make_dir_recursive_absolute(output_dir)
 
-	var new_script = FileAccess.open(GENERATED_SCRIPTS_FOLDER.path_join(cls_name + ".cs"), FileAccess.WRITE)
+	var new_script = FileAccess.open(output_dir.path_join(cls_name + ".cs"), FileAccess.WRITE)
 	new_script.store_string(code)
 
 
-func _run():
+static func generate_gdextension_csharp_scripts(output_dir := GENERATED_SCRIPTS_FOLDER):
 	var classes = ClassDB.get_class_list()
 	for cls_name in classes:
 		if _is_extension_class(cls_name):
-			generate_csharp_script(cls_name)
+			generate_csharp_script(cls_name, output_dir)
 
 
 static func _generate_enum(cls_name: StringName, enum_name: StringName) -> String:

--- a/addons/csharp_gdextension_bindgen/csharp_gdextension_bindgen.gd
+++ b/addons/csharp_gdextension_bindgen/csharp_gdextension_bindgen.gd
@@ -33,7 +33,11 @@ func _exit_tree():
 	remove_tool_menu_item(MENU_ITEM_NAME)
 
 
-static func generate_csharp_script(cls_name: StringName, output_dir := GENERATED_SCRIPTS_FOLDER):
+static func generate_csharp_script(
+	cls_name: StringName,
+	output_dir := GENERATED_SCRIPTS_FOLDER,
+	name_space := GENERATED_NAMESPACE,
+):
 	var class_is_editor_only = _is_editor_extension_class(cls_name)
 	var parent_class = ClassDB.get_parent_class(cls_name)
 	var parent_class_is_extension = _is_extension_class(parent_class)
@@ -223,14 +227,14 @@ static func generate_csharp_script(cls_name: StringName, output_dir := GENERATED
 		using System.Diagnostics.CodeAnalysis;
 		using Godot;
 
-		namespace {GENERATED_NAMESPACE};
+		namespace {name_space};
 
 		public class {cls_name}{inheritance}
 		{
 		{regions}
 		}
 	""".dedent().format({
-		GENERATED_NAMESPACE = GENERATED_NAMESPACE,
+		name_space = name_space,
 		cls_name = cls_name,
 		inheritance = " : " + parent_class if parent_class_is_extension else "",
 		regions = "\n\n".join(regions).indent("\t"),
@@ -254,11 +258,14 @@ static func generate_csharp_script(cls_name: StringName, output_dir := GENERATED
 	new_script.store_string(code)
 
 
-static func generate_gdextension_csharp_scripts(output_dir := GENERATED_SCRIPTS_FOLDER):
+static func generate_gdextension_csharp_scripts(
+	output_dir := GENERATED_SCRIPTS_FOLDER,
+	name_space := GENERATED_NAMESPACE,
+):
 	var classes = ClassDB.get_class_list()
 	for cls_name in classes:
 		if _is_extension_class(cls_name):
-			generate_csharp_script(cls_name, output_dir)
+			generate_csharp_script(cls_name, output_dir, name_space)
 
 
 static func _generate_enum(cls_name: StringName, enum_name: StringName) -> String:
@@ -268,7 +275,7 @@ static func _generate_enum(cls_name: StringName, enum_name: StringName) -> Strin
 			common_prefix = constant_name
 		else:
 			common_prefix = _get_common_prefix(common_prefix, constant_name)
-	
+
 	var constants = PackedStringArray()
 	for constant_name in ClassDB.class_get_enum_constants(cls_name, enum_name, true):
 		constants.append("{csharp_constant_name} = {constant_value}L,".format({


### PR DESCRIPTION
This is meant to be used by GDExtension projects themselves to automate generation of C# bindings.
Supports passing the desired output directory and C# namespace as optional CLI arguments.