### PR TITLE
Fix .gitattributes by not ignoring `/addons` on export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@
 
 # Only include the addons folder when downloading from the Asset Library.
 /**        export-ignore
+/addons    !export-ignore
 /addons/csharp_gdextension_bindgen    !export-ignore
 /addons/csharp_gdextension_bindgen/** !export-ignore


### PR DESCRIPTION
Fixes #3.